### PR TITLE
Kevin work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.asv
 machflow.zip
+data.mat

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.asv
+machflow.zip

--- a/animationtesting.m
+++ b/animationtesting.m
@@ -1,39 +1,18 @@
 %% --- Animator ---
-tile = tiledlayout(2, 4, 'TileSpacing', 'compact', 'Padding', 'compact');
-% initialize handles
-axesArray = gobjects(1, 8);
-h = gobjects(1, 8);
-var_labels = {'$\rho$', '$u$', '$v$', '$e$', '$p$', '$T$', '$Convergence$'};
-titles = gobjects(1, 8);
-convergence_vals = abs(squeeze(output_vars{7}(:))); 
-time = time(:);
+tile = tiledlayout(3, 3, 'TileSpacing', 'compact', 'Padding', 'compact');
 
 % initial plot for each variable
-for var = 1:7
-    axesArray(var) = nexttile(tile, var);
-    if var == 7
-        % For convergence plot (line plot)
-        h(var) = plot(axesArray(var), time(1), convergence_vals(1), 'b-');
-        xlabel(axesArray(var), '$t$', 'Interpreter','latex');
-        ylabel(axesArray(var), '$Convergence$', 'Interpreter','latex');
-        set(h(var), 'XDataSource', 'time(1:i)');
-        set(h(var), 'YDataSource', 'convergence_vals(1:i)');
-    else
-        % For field variables (pcolor plots)
-        output_frame = squeeze(output_vars{var}(:,:,1));
-        h(var) = pcolor(axesArray(var), xx, yy, output_frame);
-        shading(axesArray(var), 'interp');
-        axis(axesArray(var), 'equal', 'tight');
-        xlabel(axesArray(var), '$x$', 'Interpreter','latex');
-        ylabel(axesArray(var), '$y$', 'Interpreter','latex');
-        colorbar(axesArray(var));
-    end
-    
-    titles(var) = title(axesArray(var), ...
-        sprintf('%s at $t=%.4e$ s\n(%d/%d)', var_labels{var}, time(1), 1, step_total),'Interpreter','latex');
+for var = 1:6
+    nexttile(var)
+    pcolor(xx, yy, squeeze(output_vars{var}(:, :, 1)))
+    shading interp
+    axis equal tight
 end
 
-for i = 1:50:step_total
+nexttile(7, [1 3])
+convPlot = plot(output_vars{7});
+
+for i = 1:10:step_total
     for var = 1:7
         if var == 7
             % Update convergence plot using refreshdata

--- a/animationtesting.m
+++ b/animationtesting.m
@@ -1,28 +1,60 @@
 %% --- Animator ---
 tile = tiledlayout(3, 3, 'TileSpacing', 'compact', 'Padding', 'compact');
 
-% initial plot for each variable
-for var = 1:6
-    nexttile(var)
-    pcolor(xx, yy, squeeze(output_vars{var}(:, :, 1)))
-    shading interp
-    axis equal tight
-end
+% initialize handles
+axesArray = gobjects(1, 7);
+h = gobjects(1, 6);
+convergenceh = gobjects(1, 4);
+var_labels = {'$\rho$', '$u$', '$v$', '$e$', '$p$', '$T$', '$Convergence$'};
+titles = gobjects(1, 7);
+convergence_vals = output_vars{7}; 
+time = time(:);
 
-nexttile(7, [1 3])
-convPlot = plot(output_vars{7});
+% initial plot for each variable
+for var = 1:7
+    if var == 7
+        axesArray(var) = nexttile(tile, var, [1 3]);
+        % For convergence plot (line plot)
+        for k = 1:4
+            convergenceh(k) = plot(axesArray(var), convergence_vals(1,k));
+            set(convergenceh(k), 'XDataSource', '1:i')
+            set(convergenceh(k), 'YDataSource', 'convergence_vals(1:i,k)');
+            hold on
+        end
+        hold off
+        xlabel(axesArray(var), '$step$', 'Interpreter','latex');
+        ylabel(axesArray(var), '$Convergence$', 'Interpreter','latex');
+        legend({'$\rho$', '$\rho u$', '$\rho v$', '$E_t$'}, 'Interpreter', 'latex')
+    else
+        axesArray(var) = nexttile(tile, var);
+        % For field variables (pcolor plots)
+        output_frame = squeeze(output_vars{var}(:,:,1));
+        h(var) = pcolor(axesArray(var), xx, yy, output_frame);
+        shading(axesArray(var), 'interp');
+        axis(axesArray(var), 'equal', 'tight');
+        xlabel(axesArray(var), '$x$', 'Interpreter','latex');
+        ylabel(axesArray(var), '$y$', 'Interpreter','latex');
+        colorbar(axesArray(var));
+        titles(var) = title(var_labels{var}, 'Interpreter', 'latex');
+    end
+    
+    tiletitle = title(tile, ...
+        sprintf('$t=%.4e$ s\n(%d/%d)', time(1), 1, step_total),'Interpreter','latex');
+end
 
 for i = 1:10:step_total
     for var = 1:7
         if var == 7
-            % Update convergence plot using refreshdata
-            refreshdata(h(var), 'caller');
-            % Adjust axes limits if needed
-            if i > 1
-                axesArray(var).XLim = [time(1), time(i)];
-                ylims = [min(convergence_vals(1:i)), max(convergence_vals(1:i))];
-                if ylims(1) ~= ylims(2)  % Only adjust if not constant
-                    axesArray(var).YLim = ylims;
+            for k = 1:4
+                % Update convergence plot using refreshdata
+                refreshdata(convergenceh(k), 'caller');
+                % Adjust axes limits if needed
+                if i > 1
+                    axesArray(var).XLim = [0, i];
+                    ylims = [min(convergence_vals(1:i,:), [], 'all'), max(convergence_vals(1:i, :), [], 'all')];
+                    if ylims(1) ~= ylims(2)  % Only adjust if not constant
+                        axesArray(var).YLim = ylims;
+                    end
                 end
             end
         else
@@ -31,7 +63,7 @@ for i = 1:10:step_total
             h(var).CData = output_frame;
         end
         % Update titles
-        titles(var).String = sprintf('%s at $t=%.4e$ s\n(%d/%d)', var_labels{var}, time(i), i, step_total);
+        tiletitle.String = sprintf('$t=%.3f$ ns (%d/%d)', time(i) * 1e9, i, step_total);
     end
     drawnow;
 end

--- a/animationtesting.m
+++ b/animationtesting.m
@@ -16,7 +16,7 @@ for var = 1:7
         axesArray(var) = nexttile(tile, var, [1 3]);
         % For convergence plot (line plot)
         for k = 1:4
-            convergenceh(k) = plot(axesArray(var), convergence_vals(1,k));
+            convergenceh(k) = semilogy(axesArray(var), convergence_vals(1,k));
             set(convergenceh(k), 'XDataSource', '1:i')
             set(convergenceh(k), 'YDataSource', 'convergence_vals(1:i,k)');
             hold on
@@ -38,11 +38,10 @@ for var = 1:7
         titles(var) = title(var_labels{var}, 'Interpreter', 'latex');
     end
     
-    tiletitle = title(tile, ...
-        sprintf('$t=%.4e$ s\n(%d/%d)', time(1), 1, step_total),'Interpreter','latex');
+    tiletitle = title(tile, sprintf('Step %d/%d', i, step_total));
 end
 
-for i = 1:10:step_total
+for i = 1:50:step_total
     for var = 1:7
         if var == 7
             for k = 1:4
@@ -63,7 +62,7 @@ for i = 1:10:step_total
             h(var).CData = output_frame;
         end
         % Update titles
-        tiletitle.String = sprintf('$t=%.3f$ ns (%d/%d)', time(i) * 1e9, i, step_total);
+        tiletitle.String = sprintf('Step %d/%d', i, step_total);
     end
     drawnow;
 end

--- a/bc_enforcer.m
+++ b/bc_enforcer.m
@@ -6,28 +6,32 @@ function [rho, u, v, T, p, e, Et] = bc_enforcer(u, v, T, p, cv, R, uinf, pinf, T
     T(end,:) = 2*(T(end-1,:)) - T(end-2,:);
 
     % Bottom wall
-    u(:, 1) = 0;
-    v(:, 1) = 0;
-    T(:, 1) = Tinf;
-    p(:, 1) = 2*(p(:,2)) - p(:,3);
+    u(2:end, 1) = 0;
+    v(2:end, 1) = 0;
+    T(2:end, 1) = Tinf;
+    p(2:end, 1) = 2*(p(2:end,2)) - p(2:end,3);
+
+    % Inlet
+    u(1, 2:end) = uinf;
+    v(1, 2:end) = 0;
+    p(1, 2:end) = pinf;
+    T(1, 2:end) = Tinf;
+    
+    % Far field
+    % u(:, end) = uinf;
+    % v(:, end) = 0;
+    % p(:, end) = pinf;
+    % T(:, end) = Tinf;
+    u(:, end) = 2*u(:, end-1) - u(:, end-2);
+    v(:, end) = 2*v(:, end-1) - v(:, end-2);
+    p(:, end) = 2*p(:, end-1) - p(:, end-2);
+    T(:, end) = 2*T(:, end-1) - T(:, end-2);
 
     % Leading edge
     u(1,1) = 0;
     v(1,1) = 0;
     p(1,1) = pinf;
     T(1,1) = Tinf;
-    
-    % Inlet
-    u(1, :) = uinf;
-    v(1, :) = 0;
-    p(1, :) = pinf;
-    T(1, :) = Tinf;
-    
-    % Far field
-    u(:, end) = uinf;
-    v(:, end) = 0;
-    p(:, end) = pinf;
-    T(:, end) = Tinf;
 
     rho = p./(R.*T);
     e = cv.*T;

--- a/bc_enforcer.m
+++ b/bc_enforcer.m
@@ -1,10 +1,5 @@
 function [rho, u, v, T, p, e, Et] = bc_enforcer(u, v, T, p, cv, R, uinf, pinf, Tinf)
-    % Outlet
-    u(end,:) = 2*(u(end-1,:)) - u(end-2,:);
-    v(end,:) = 2*(v(end-1,:)) - v(end-2,:);
-    p(end,:) = 2*(p(end-1,:)) - p(end-2,:);
-    T(end,:) = 2*(T(end-1,:)) - T(end-2,:);
-
+    
     % Bottom wall
     u(2:end, 1) = 0;
     v(2:end, 1) = 0;
@@ -18,14 +13,16 @@ function [rho, u, v, T, p, e, Et] = bc_enforcer(u, v, T, p, cv, R, uinf, pinf, T
     T(1, 2:end) = Tinf;
     
     % Far field
-    % u(:, end) = uinf;
-    % v(:, end) = 0;
-    % p(:, end) = pinf;
-    % T(:, end) = Tinf;
-    u(:, end) = 2*u(:, end-1) - u(:, end-2);
-    v(:, end) = 2*v(:, end-1) - v(:, end-2);
-    p(:, end) = 2*p(:, end-1) - p(:, end-2);
-    T(:, end) = 2*T(:, end-1) - T(:, end-2);
+    u(:, end) = uinf;
+    v(:, end) = 0;
+    p(:, end) = pinf;
+    T(:, end) = Tinf;
+
+    % Outlet
+    u(end,:) = 2*(u(end-1,:)) - u(end-2,:);
+    v(end,:) = 2*(v(end-1,:)) - v(end-2,:);
+    p(end,:) = 2*(p(end-1,:)) - p(end-2,:);
+    T(end,:) = 2*(T(end-1,:)) - T(end-2,:);
 
     % Leading edge
     u(1,1) = 0;

--- a/mach_angle.m
+++ b/mach_angle.m
@@ -1,0 +1,25 @@
+theta = asin(1/M);
+y_end = L * tan(theta);
+tile = tiledlayout(1, 1, 'TileSpacing', 'compact', 'Padding', 'compact');
+% initialize handles
+axesArray = gobjects(1, 1);
+h = gobjects(1, 1);
+titles = gobjects(1, 1);
+for var = 1:1
+    axesArray(var) = nexttile(tile, var);
+    output_frame = squeeze(output_vars{3}(:,:,step_total));
+    hold on
+    h(var) = pcolor(axesArray(var), xx, yy, output_frame);
+    h2(var) = line(axesArray(var), [0 L], [0 y_end]);
+    hold off
+    shading(axesArray(var), 'interp');
+    axis(axesArray(var), 'equal', 'tight');
+    xlabel(axesArray(var), '$x$', 'Interpreter','latex');
+    ylabel(axesArray(var), '$y$', 'Interpreter','latex');
+    xlim(axesArray(var),[0 L])
+    ylim(axesArray(var),[0 H])
+    colorbar(axesArray(var));
+    titles(var) = title(axesArray(var), ...
+    sprintf('M = %d', M),'Interpreter','latex');
+end
+drawnow;

--- a/main.m
+++ b/main.m
@@ -19,15 +19,19 @@ convergence = zeros(step_total+1, 4);
 for step = 1:step_total
     % I/O, loop updates, delta_t_CFL, visualization
 
-    % compute delta_t CFL
-    dt = 2.35e-11; % Constant time step (s)
-    time(step+1) = time(step) + dt;
-
     %%%%%% Predictor %%%%%%
 
     % update mu, k
     mu = sutherland(T);
     k = (cp/Pr)*mu;
+    
+    % compute delta_t CFL
+    a = sqrt(gamma .* R .* T);
+    vprime = max(4 / 3 .* u .* (k .* u ./ Pr) ./ rho, [], 'all');
+    dtCFL = min((abs(u)./dx + abs(v)./dy + a .* sqrt(1/(dx^2) + 1/(dy^2)) + 2 .* vprime .* (1/(dx^2) + 1/(dy^2))).^(-1), [], 'all');
+    dt = 2.35e-11; % Constant time step (s)
+    dt = dtCFL;
+    time(step+1) = time(step) + dt;
 
     % compute derivatives, update E, F
     if mod(step, 2) == 0

--- a/main.m
+++ b/main.m
@@ -27,12 +27,12 @@ for step = 1:step_total
     
     % compute delta_t CFL
     a = sqrt(gamma .* R .* T);
-    vprime = max(4 / 3 .* u .* (k .* u ./ Pr) ./ rho, [], 'all');
-    dtCFL = min((abs(u)./dx + abs(v)./dy + a .* sqrt(1/(dx^2) + 1/(dy^2)) + 2 .* vprime .* (1/(dx^2) + 1/(dy^2))).^(-1), [], 'all');
+    vprime = max(4 / 3 .* mu .* (k .* mu ./ Pr) ./ rho, [], 'all');
+    dtCFL = (abs(u)./dx + abs(v)./dy + a .* sqrt(1/(dx^2) + 1/(dy^2)) + 2 .* vprime .* (1/(dx^2) + 1/(dy^2))).^(-1);
     dt = 2.35e-11; % Constant time step (s)
-    dt = dtCFL;
     time(step+1) = time(step) + dt;
-
+    %dt = permute(repmat(dtCFL,[1 1 4]), [3 1 2]);
+    
     % compute derivatives, update E, F
     if mod(step, 2) == 0
         [E, F] = flux('backward', U, dx, dy, mu, k, R, cv);
@@ -45,7 +45,7 @@ for step = 1:step_total
     end
 
     % compute U_bar using U, E, F
-    UBar = U - dt * (Edx + Fdy);
+    UBar = U - dt .* (Edx + Fdy);
 
     % compute primitive var's from U_bar
     [rhoBar, uBar, vBar, TBar, pBar, eBar, EtBar] = cons2prim(UBar, R, cv);
@@ -91,7 +91,9 @@ for step = 1:step_total
     new_vars = {rho, u, v, e, p, T};
 
     for i = 1:4
-        convergence(step+1, i) = max(abs(U(i, :, :) - U_prev(i, :, :)) ./ (0.5 * (abs(U(i, :, :)) + abs(U_prev(i, :, :))) + eps), [], 'all');
+        % convergence(step+1, i) = max(abs(U(i, :, :) - U_prev(i, :, :)) ./ (0.5 * (abs(U(i, :, :)) + abs(U_prev(i, :, :))) + eps), [], 'all');
+        % convergence(step+1, i) = sqrt(mean((U(i,:,:) - U_prev(i,:,:)).^2, 'all'));
+        convergence(step+1, i) = sqrt(mean((U(i,:,:) - U_prev(i,:,:)).^2, 'all')) / max(abs(U(i,:,:)), [], 'all');
     end
 
     for k = 1:6

--- a/num_schlieren.m
+++ b/num_schlieren.m
@@ -1,0 +1,15 @@
+figure;
+
+beta = 0.8;
+kappa = 10;
+gradp = sqrt(ddx_central(output_vars{5}(:,:,step_total),dx,1).^2 + ddx_central(output_vars{5}(:,:,step_total),dy,2).^2);
+S = beta*exp(-kappa*(gradp./(max(gradp))));
+pcolor(xx,yy,S)
+shading('interp')
+colormap(gray)
+colorbar
+clim([0, 1])
+xlabel('$x$', 'Interpreter','latex')
+ylabel('$y$', 'Interpreter','latex')
+title('Numerical Schlieren','Interpreter','latex')
+axis equal tight

--- a/setup.m
+++ b/setup.m
@@ -13,10 +13,13 @@ M = 4;                      % Mach Number
 
 a0 = sqrt(gamma * R * T0);  % Speed of Sound
 uinf = a0 * M;              % Free-stream velocity
-Tinf = T0 * (1 + (gamma - 1)/2 * M^2);                     % Static temperature
-pinf = p0 * (1 + (gamma - 1)/2 * M^2)^(gamma / (gamma - 1)); % Static pressure
+% Tinf = T0 * (1 + (gamma - 1)/2 * M^2);                     % Static temperature
+% pinf = p0 * (1 + (gamma - 1)/2 * M^2)^(gamma / (gamma - 1)); % Static pressure
+pinf = p0;
+Tinf = T0;
 
 %% Grid setup
+
 nx = 75;    % x Number of points
 ny = 80;    % y Number of points
 L = 1e-5;   % Length of computational domain (m)

--- a/setup.m
+++ b/setup.m
@@ -51,4 +51,5 @@ T(:, :) = Tinf;
 %   4 - total energy
 % set U(:,:,:,step 1) to BC's
 U(:,:,:) = prim2cons(rho,u,v,T,cv);
-p_previous = p;
+new_vars = {rho, u, v, e, p, T};
+U_prev = U;


### PR DESCRIPTION
- Updated branch with new Part 2 functions (Numerical Schlieren & Mach Angle)
- Animating all 4 residuals of conservative variables
- Boundary condition at leading edge was getting overwritten, moved it later in the code and also changed limits of other BCs as  a redundancy
- Set T_inf & p_inf to sea-level standard conditions (1)
- Residual values are now normalized by the magnitude of the variable (shows that they are converging)

1. Simulating the plate itself moving is more meaningful 

TO DO:
- Maybe apply CFL condition locally (no more global time)